### PR TITLE
Force Mono when enabled

### DIFF
--- a/src/com/android/launcher3/config/FeatureFlags.java
+++ b/src/com/android/launcher3/config/FeatureFlags.java
@@ -163,7 +163,7 @@ public final class FeatureFlags {
 
     // TODO(Block 7): Clean up flags
     public static final BooleanFlag ENABLE_FORCED_MONO_ICON = getDebugFlag(270396209,
-            "ENABLE_FORCED_MONO_ICON", DISABLED,
+            "ENABLE_FORCED_MONO_ICON", ENABLED,
             "Enable the ability to generate monochromatic icons, if it is not provided by the app");
 
     // TODO(Block 8): Clean up flags


### PR DESCRIPTION
Enables Android to automatically generate monochromatic icons to use for monet.

Some icons can look weird but it's still better than a mismatched homescreen

Only turns on when Themed Icons is enabled, so this seems fine

Change-Id: I4a4b84051a4e09fda40faa438706c25958713f4a